### PR TITLE
Adding a content addressable cache

### DIFF
--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -950,7 +950,7 @@ use_new_feature = partial(
     metavar="feature",
     action="append",
     default=[],
-    choices=["2020-resolver", "fast-deps", "in-tree-build"],
+    choices=["2020-resolver", "fast-deps", "in-tree-build", "content-addressable-pool"],
     help="Enable new functionality, that may be backward incompatible.",
 )  # type: Callable[..., Option]
 

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -409,17 +409,24 @@ class InstallCommand(RequirementCommand):
             content_addressable_pool = "content-addressable-pool" in options.features_enabled
             pool = None  # type: Optional[ContentAddressablePool]
             if content_addressable_pool:
-                logger.warning(
-                    "pip is using a content-addressable pool to install files "
-                    "from. This experimental feature is enabled through "
-                    "--use-feature=content-addressable-pool and it is not "
-                    "ready for production."
-                )
-                pool = ContentAddressablePool(
-                    options.cache_dir,
-                    save=options.content_addressable_pool_save_files,
-                    symlink=options.content_addressable_pool_symlink,
-                )
+                if options.cache_dir is None:
+                    logger.warning(
+                        "--use-feature=content-addressable-pool can only be used when "
+                        "the pip cache directory is enabled and configured. The option "
+                        "will be ignored."
+                    )
+                else:
+                    logger.warning(
+                        "pip is using a content-addressable pool to install files "
+                        "from. This experimental feature is enabled through "
+                        "--use-feature=content-addressable-pool and it is not "
+                        "ready for production."
+                    )
+                    pool = ContentAddressablePool(
+                        options.cache_dir,
+                        save=options.content_addressable_pool_save_files,
+                        symlink=options.content_addressable_pool_symlink,
+                    )
 
             installed = install_given_reqs(
                 to_install,

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -222,7 +222,8 @@ class InstallCommand(RequirementCommand):
             action="store_true",
             dest="content_addressable_pool_symlink",
             default=False,
-            help="Use symlinks (instead of hard links) for the content-addressable pool files",
+            help="Use symlinks (instead of hard links) for the "
+                 "content-addressable pool files",
         )
 
         self.cmd_opts.add_option(cmdoptions.no_binary())
@@ -406,7 +407,8 @@ class InstallCommand(RequirementCommand):
             if options.target_dir or options.prefix_path:
                 warn_script_location = False
 
-            content_addressable_pool = "content-addressable-pool" in options.features_enabled
+            content_addressable_pool = "content-addressable-pool" \
+                                       in options.features_enabled
             pool = None  # type: Optional[ContentAddressablePool]
             if content_addressable_pool:
                 if options.cache_dir is None:

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -407,8 +407,8 @@ class InstallCommand(RequirementCommand):
             if options.target_dir or options.prefix_path:
                 warn_script_location = False
 
-            content_addressable_pool = "content-addressable-pool" \
-                                       in options.features_enabled
+            content_addressable_pool = ("content-addressable-pool" 
+                                        in options.features_enabled)
             pool = None  # type: Optional[ContentAddressablePool]
             if content_addressable_pool:
                 if options.cache_dir is None:

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -407,7 +407,7 @@ class InstallCommand(RequirementCommand):
             if options.target_dir or options.prefix_path:
                 warn_script_location = False
 
-            content_addressable_pool = ("content-addressable-pool" 
+            content_addressable_pool = ("content-addressable-pool"
                                         in options.features_enabled)
             pool = None  # type: Optional[ContentAddressablePool]
             if content_addressable_pool:

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -495,7 +495,7 @@ class ScriptFile:
         self.changed = False
 
     def save(self):
-        # type: (ScriptFile) -> None
+        # type: () -> None
         self._file.save()
         self.changed = fix_script(self.dest_path)
 

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -482,7 +482,7 @@ class ZipBackedFile:
             except OSError:
                 # This is moderately expected. Fall back to copy.
                 pass
-        
+
         _save(self.dest_path, writable=True)
 
 

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -495,7 +495,7 @@ class ScriptFile:
         self.changed = False
 
     def save(self):
-        # type: (str) -> None
+        # type: (ScriptFile) -> None
         self._file.save()
         self.changed = fix_script(self.dest_path)
 
@@ -571,13 +571,13 @@ def _install_wheel(
         for row in record_rows:
             if len(row) < 3:
                 continue
-            record_path = _parse_record_path(row[0])
+            parsed_record_path = _parse_record_path(row[0])
             if '=' not in row[1]:
                 continue
             digest_name, b64hash = row[1].split('=', 1)
             if digest_name != 'sha256':
                 continue
-            digests[record_path] = urlsafe_b64decode(f'{b64hash}=').hex()
+            digests[parsed_record_path] = urlsafe_b64decode(f'{b64hash}=').hex()
 
     # Record details of the files moved
     #   installed = files copied from the wheel to the destination

--- a/src/pip/_internal/req/__init__.py
+++ b/src/pip/_internal/req/__init__.py
@@ -2,6 +2,7 @@ import collections
 import logging
 from typing import Iterator, List, Optional, Sequence, Tuple
 
+from pip._internal.operations.install.wheel import ContentAddressablePool
 from pip._internal.utils.logging import indent_log
 
 from .req_file import parse_requirements
@@ -45,6 +46,7 @@ def install_given_reqs(
     warn_script_location,  # type: bool
     use_user_site,  # type: bool
     pycompile,  # type: bool
+    pool,  # type: Optional[ContentAddressablePool]
 ):
     # type: (...) -> List[InstallationResult]
     """
@@ -83,6 +85,7 @@ def install_given_reqs(
                     warn_script_location=warn_script_location,
                     use_user_site=use_user_site,
                     pycompile=pycompile,
+                    pool=pool,
                 )
             except Exception:
                 # if install did not succeed, rollback previous uninstall

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -32,7 +32,10 @@ from pip._internal.operations.install.editable_legacy import (
 )
 from pip._internal.operations.install.legacy import LegacyInstallFailure
 from pip._internal.operations.install.legacy import install as install_legacy
-from pip._internal.operations.install.wheel import install_wheel
+from pip._internal.operations.install.wheel import (
+    ContentAddressablePool,
+    install_wheel,
+)
 from pip._internal.pyproject import load_pyproject_toml, make_pyproject_path
 from pip._internal.req.req_uninstall import UninstallPathSet
 from pip._internal.utils.deprecation import deprecated
@@ -746,7 +749,8 @@ class InstallRequirement:
         prefix=None,  # type: Optional[str]
         warn_script_location=True,  # type: bool
         use_user_site=False,  # type: bool
-        pycompile=True  # type: bool
+        pycompile=True,  # type: bool
+        pool=None  # type: Optional[ContentAddressablePool]
     ):
         # type: (...) -> None
         scheme = get_scheme(
@@ -793,6 +797,7 @@ class InstallRequirement:
                 warn_script_location=warn_script_location,
                 direct_url=direct_url,
                 requested=self.user_supplied,
+                pool=pool,
             )
             self.install_succeeded = True
             return
@@ -823,6 +828,7 @@ class InstallRequirement:
                 build_env=self.build_env,
                 unpacked_source_directory=self.unpacked_source_directory,
                 req_description=str(self.req),
+                cache_dir=cache_dir,
             )
         except LegacyInstallFailure as exc:
             self.install_succeeded = False

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -32,10 +32,7 @@ from pip._internal.operations.install.editable_legacy import (
 )
 from pip._internal.operations.install.legacy import LegacyInstallFailure
 from pip._internal.operations.install.legacy import install as install_legacy
-from pip._internal.operations.install.wheel import (
-    ContentAddressablePool,
-    install_wheel,
-)
+from pip._internal.operations.install.wheel import ContentAddressablePool, install_wheel
 from pip._internal.pyproject import load_pyproject_toml, make_pyproject_path
 from pip._internal.req.req_uninstall import UninstallPathSet
 from pip._internal.utils.deprecation import deprecated

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -825,7 +825,6 @@ class InstallRequirement:
                 build_env=self.build_env,
                 unpacked_source_directory=self.unpacked_source_directory,
                 req_description=str(self.req),
-                cache_dir=cache_dir,
             )
         except LegacyInstallFailure as exc:
             self.install_succeeded = False

--- a/src/pip/_internal/utils/unpacking.py
+++ b/src/pip/_internal/utils/unpacking.py
@@ -89,13 +89,17 @@ def is_within_directory(directory, target):
     return prefix == abs_directory
 
 
-def set_extracted_file_to_default_mode_plus_executable(path):
-    # type: (str) -> None
+def set_extracted_file_to_default_mode_plus_executable(path, writable=True):
+    # type: (str, bool) -> None
     """
     Make file present at path have execute for user/group/world
     (chmod +x) is no-op on windows per python docs
     """
-    os.chmod(path, (0o777 & ~current_umask() | 0o111))
+    if writable:
+        mask = 0o777
+    else:
+        mask = 0o555
+    os.chmod(path, (mask & ~current_umask() | 0o111))
 
 
 def zip_item_is_executable(info):

--- a/tests/functional/test_install_wheel.py
+++ b/tests/functional/test_install_wheel.py
@@ -605,7 +605,10 @@ def test_wheel_install_with_ca_pool(script, tmpdir, data):
     )
     valid = [
         os.path.exists(ca_file_path),
-        os.path.samefile(script.site_packages_path / 'simpledist/__init__.py', ca_file_path),
+        os.path.samefile(
+            script.site_packages_path / 'simpledist/__init__.py',
+            ca_file_path,
+        ),
     ]
 
     result.assert_installed('simpledist', editable=False)

--- a/tests/functional/test_install_wheel.py
+++ b/tests/functional/test_install_wheel.py
@@ -589,7 +589,7 @@ def test_wheel_install_with_ca_pool(script, tmpdir, data):
         allow_stderr_warning=True
     )
 
-    # This is the sha of the simple.dist-0.1-py2.py3-none-any.whl wheel file
+    # This is the sha of the `simpledist/__init__.py` file inside the wheel.
     digest_name, b64hash = \
         'sha256=47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU'.split('=', 1)
     path = urlsafe_b64decode(f'{b64hash}=').hex()

--- a/tests/functional/test_install_wheel.py
+++ b/tests/functional/test_install_wheel.py
@@ -653,6 +653,7 @@ def test_wheel_install_with_ca_pool_without_cache_dir(script, tmpdir, data):
     assert '--use-feature=content-addressable-pool can only be used when' not in result.stdout
     assert not any(exists)
 
+
 def test_wheel_install_fails_with_extra_dist_info(script):
     package = create_basic_wheel_for_package(
         script,

--- a/tests/functional/test_install_wheel.py
+++ b/tests/functional/test_install_wheel.py
@@ -3,7 +3,7 @@ import distutils
 import glob
 import os
 import shutil
-from base64 import urlsafe_b64decode, urlsafe_b64encode
+from base64 import urlsafe_b64decode
 
 import pytest
 
@@ -590,7 +590,8 @@ def test_wheel_install_with_ca_pool(script, tmpdir, data):
     )
 
     # This is the sha of the simple.dist-0.1-py2.py3-none-any.whl wheel file
-    digest_name, b64hash = 'sha256=47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU'.split('=', 1)
+    digest_name, b64hash = \
+        'sha256=47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU'.split('=', 1)
     path = urlsafe_b64decode(f'{b64hash}=').hex()
 
     # Make sure the path of the wheel we installed is safely installed in the cacache
@@ -613,7 +614,8 @@ def test_wheel_install_with_ca_pool(script, tmpdir, data):
 
 
 def test_wheel_install_with_ca_pool_without_saving(script, tmpdir, data):
-    """Check wheel installations work when set to use a content addressable pool, but without the save option
+    """Check wheel installations work when set to use a content addressable pool,
+    but without the save option
     """
     package = data.packages.joinpath("simple.dist-0.1-py2.py3-none-any.whl")
     result = script.pip(
@@ -634,8 +636,9 @@ def test_wheel_install_with_ca_pool_without_saving(script, tmpdir, data):
 
 
 def test_wheel_install_with_ca_pool_without_cache_dir(script, tmpdir, data):
-    """Check wheel installations work when set to use a content addressable pool, but without any
-    cache dir configured. should return a warning.
+    """Check wheel installations work when set to use a content
+    addressable pool, but without any cache dir configured.
+    Should trigger a warning.
     """
     package = data.packages.joinpath("simple.dist-0.1-py2.py3-none-any.whl")
     result = script.pip(
@@ -650,7 +653,8 @@ def test_wheel_install_with_ca_pool_without_cache_dir(script, tmpdir, data):
         os.path.exists(script.cwd / "cache/pool"),
     ]
 
-    assert '--use-feature=content-addressable-pool can only be used when' not in result.stdout
+    assert '--use-feature=content-addressable-pool ' \
+           'can only be used when' not in result.stdout
     assert not any(exists)
 
 

--- a/tests/functional/test_install_wheel.py
+++ b/tests/functional/test_install_wheel.py
@@ -594,7 +594,7 @@ def test_wheel_install_with_ca_pool(script, tmpdir, data):
         'sha256=47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU'.split('=', 1)
     path = urlsafe_b64decode(f'{b64hash}=').hex()
 
-    # Make sure the path of the wheel we installed is safely installed in the cacache
+    # Make sure the path of the file we installed is safely installed in the cacache
     exists = [
         os.path.exists(
             os.path.join(


### PR DESCRIPTION
This change makes pip try to link (or symlink) files from a content-addressable pool instead of as files when installing from a wheel. This makes it possible to save a lot of space when installing packages on systems with several virtualenvs.