### PR TITLE
Replit: Add a flag to make pip install do nothing

### DIFF
--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -197,6 +197,14 @@ class InstallCommand(RequirementCommand):
         )
 
         self.cmd_opts.add_option(
+            "--noop",
+            action="store_true",
+            dest="noop",
+            default=False,
+            help="Download and cache artifacts but do not actually install anything",
+        )
+
+        self.cmd_opts.add_option(
             "--no-warn-script-location",
             action="store_false",
             dest="warn_script_location",
@@ -440,6 +448,7 @@ class InstallCommand(RequirementCommand):
                 warn_script_location=warn_script_location,
                 use_user_site=options.use_user_site,
                 pycompile=options.compile,
+                noop=options.noop,
                 pool=pool,
             )
 

--- a/src/pip/_internal/operations/install/legacy.py
+++ b/src/pip/_internal/operations/install/legacy.py
@@ -33,6 +33,7 @@ def install(
     prefix,  # type: Optional[str]
     use_user_site,  # type: bool
     pycompile,  # type: bool
+    noop,  # type: bool
     scheme,  # type: Scheme
     setup_py_path,  # type: str
     isolated,  # type: bool
@@ -42,6 +43,10 @@ def install(
     req_description,  # type: str
 ):
     # type: (...) -> bool
+
+    if noop:
+        # Nothing to do here.
+        return True
 
     header_dir = scheme.headers
 

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -536,6 +536,7 @@ def _install_wheel(
     wheel_path,  # type: str
     scheme,  # type: Scheme
     pycompile=True,  # type: bool
+    noop=False,  # type: bool
     warn_script_location=True,  # type: bool
     direct_url=None,  # type: Optional[DirectUrl]
     requested=False,  # type: bool
@@ -747,6 +748,10 @@ def _install_wheel(
     script_scheme_files = map(ScriptFile, script_scheme_files)
     files = chain(files, script_scheme_files)
 
+    if noop:
+        # Nothing to do here.
+        return
+
     for file in files:
         file.save()
         record_installed(file.src_record_path, file.dest_path, file.changed)
@@ -895,6 +900,7 @@ def install_wheel(
     scheme,  # type: Scheme
     req_description,  # type: str
     pycompile=True,  # type: bool
+    noop=False,  # type: bool
     warn_script_location=True,  # type: bool
     direct_url=None,  # type: Optional[DirectUrl]
     requested=False,  # type: bool
@@ -909,6 +915,7 @@ def install_wheel(
                 wheel_path=wheel_path,
                 scheme=scheme,
                 pycompile=pycompile,
+                noop=noop,
                 warn_script_location=warn_script_location,
                 direct_url=direct_url,
                 requested=requested,

--- a/src/pip/_internal/req/__init__.py
+++ b/src/pip/_internal/req/__init__.py
@@ -46,6 +46,7 @@ def install_given_reqs(
     warn_script_location,  # type: bool
     use_user_site,  # type: bool
     pycompile,  # type: bool
+    noop,  # type: bool
     pool,  # type: Optional[ContentAddressablePool]
 ):
     # type: (...) -> List[InstallationResult]
@@ -85,6 +86,7 @@ def install_given_reqs(
                     warn_script_location=warn_script_location,
                     use_user_site=use_user_site,
                     pycompile=pycompile,
+                    noop=noop,
                     pool=pool,
                 )
             except Exception:

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -747,6 +747,7 @@ class InstallRequirement:
         warn_script_location=True,  # type: bool
         use_user_site=False,  # type: bool
         pycompile=True,  # type: bool
+        noop=False,  # type: bool
         pool=None  # type: Optional[ContentAddressablePool]
     ):
         # type: (...) -> None
@@ -791,6 +792,7 @@ class InstallRequirement:
                 scheme=scheme,
                 req_description=str(self.req),
                 pycompile=pycompile,
+                noop=noop,
                 warn_script_location=warn_script_location,
                 direct_url=direct_url,
                 requested=self.user_supplied,
@@ -818,6 +820,7 @@ class InstallRequirement:
                 prefix=prefix,
                 use_user_site=use_user_site,
                 pycompile=pycompile,
+                noop=noop,
                 scheme=scheme,
                 setup_py_path=self.setup_py_path,
                 isolated=self.isolated,


### PR DESCRIPTION
# Why

https://replit.slack.com/archives/C02QDF61B46/p1639674327085100?thread_ts=1639600517.054700&cid=C02QDF61B46

Previously, we were wasting a lot of time actually installing the
packages into a temporary directory, but what we really want is just to
download the artifacts so that the cache is populated.

# What changed

This change adds a new flag `--noop` to `pip install` that instructs it
to not actually ... you know, install.

# Test

```shell
mkdir tmp cacherino
python3 src/pip/ install --noop --target tmp --cache-dir cacherino/ replit==3.2.4
find tmp # empty
find cacherino # full
```