### PR TITLE
Replit: Fix the standalone pip zip

### DIFF
--- a/src/pip/_internal/build_env.py
+++ b/src/pip/_internal/build_env.py
@@ -48,7 +48,10 @@ def _create_standalone_pip() -> Iterator[str]:
     The zip file's content is identical to the currently-running pip.
     It will be used to install requirements into the build environment.
     """
-    source = pathlib.Path(pip_location).resolve().parent
+    # Replit mod: the pip binary is a symlink to the content-addressable cache,
+    # so the original `.resolve()` was causing the zip to have some _very_
+    # unexpected contents.
+    source = pathlib.Path(pip_location).parent
 
     # Return the current instance if `source` is not a directory. We can't build
     # a zip from this, and it likely means the instance is already standalone.


### PR DESCRIPTION
With the content-addressable cache, `_create_standalone_pip()` would try
to resolve the path of the `__init__.py` file of the `pip` module. Since
that file is a symlink, the path resolution would end up deep inside the
content-addressable cache, causing the generated file to have a single
file with a very unexpected name (the last two components of the sha256
hash of the `__init__.py` file). This meant that if anybody tried to
install any package from source, it would fail miserably because Python
would not be able to find the `pip` module inside the .zip file.

This change skips the resolution part so that pip can create a correct
.zip file with the expected contents.