### PR TITLE
Use a read-only cache adapter for downloading files to workaround mem…

### DIFF
--- a/src/pip/_internal/network/ro_cache_adapter.py
+++ b/src/pip/_internal/network/ro_cache_adapter.py
@@ -1,0 +1,68 @@
+import zlib
+
+from pip._vendor.requests.adapters import HTTPAdapter
+
+from pip._vendor.cachecontrol.controller import CacheController
+from pip._vendor.cachecontrol.cache import DictCache
+from pip._vendor.cachecontrol.filewrapper import CallbackFileWrapper
+
+
+class ReadOnlyCacheControlAdapter(HTTPAdapter):
+    invalidating_methods = {"PUT", "DELETE"}
+
+    def __init__(
+        self,
+        cache=None,
+        cache_etags=True,
+        controller_class=None,
+        serializer=None,
+        heuristic=None,
+        cacheable_methods=None,
+        *args,
+        **kw
+    ):
+        super(ReadOnlyCacheControlAdapter, self).__init__(*args, **kw)
+        self.cache = DictCache() if cache is None else cache
+        self.heuristic = heuristic
+        self.cacheable_methods = cacheable_methods or ("GET",)
+
+        controller_factory = controller_class or CacheController
+        self.controller = controller_factory(
+            self.cache, cache_etags=cache_etags, serializer=serializer
+        )
+
+    def send(self, request, cacheable_methods=None, **kw):
+        """
+        Send a request. Use the request information to see if it
+        exists in the cache and cache the response if we need to and can.
+        """
+        cacheable = cacheable_methods or self.cacheable_methods
+        if request.method in cacheable:
+            try:
+                cached_response = self.controller.cached_request(request)
+            except zlib.error:
+                cached_response = None
+            if cached_response:
+                return self.build_response(request, cached_response, from_cache=True)
+
+        resp = super(ReadOnlyCacheControlAdapter, self).send(request, **kw)
+
+        return resp
+
+    def build_response(
+        self, request, response, from_cache=False, cacheable_methods=None
+    ):
+        """
+        Build a response by making a request or using the cache.
+        """
+        
+        resp = super(ReadOnlyCacheControlAdapter, self).build_response(request, response)
+
+        # Give the request a from_cache attr to let people use it
+        resp.from_cache = from_cache
+
+        return resp
+
+    def close(self):
+        self.cache.close()
+        super(ReadOnlyCacheControlAdapter, self).close()

--- a/src/pip/_internal/network/session.py
+++ b/src/pip/_internal/network/session.py
@@ -27,7 +27,7 @@ import warnings
 from typing import Any, Dict, Iterator, List, Mapping, Optional, Sequence, Tuple, Union
 
 from pip._vendor import requests, urllib3
-from pip._vendor.cachecontrol import CacheControlAdapter
+from .ro_cache_adapter import ReadOnlyCacheControlAdapter
 from pip._vendor.requests.adapters import BaseAdapter, HTTPAdapter
 from pip._vendor.requests.models import PreparedRequest, Response
 from pip._vendor.requests.structures import CaseInsensitiveDict
@@ -251,7 +251,7 @@ class InsecureHTTPAdapter(HTTPAdapter):
         super().cert_verify(conn=conn, url=url, verify=False, cert=cert)
 
 
-class InsecureCacheControlAdapter(CacheControlAdapter):
+class InsecureCacheControlAdapter(ReadOnlyCacheControlAdapter):
 
     def cert_verify(
         self,
@@ -327,7 +327,7 @@ class PipSession(requests.Session):
         # origin, and we don't want someone to be able to poison the cache and
         # require manual eviction from the cache to fix it.
         if cache:
-            secure_adapter = CacheControlAdapter(
+            secure_adapter = ReadOnlyCacheControlAdapter(
                 cache=SafeFileCache(cache),
                 max_retries=retries,
             )


### PR DESCRIPTION
… usage issue

# Why?

We have experienced and seen reports of poetry/pip running out of memory when installing certain large pypi packages:

1. https://ask.replit.com/t/replit-does-not-allocate-enough-resources-when-installing-python-packages/2494
2. https://replit.slack.com/archives/C03KS2B221W/p1669004177362729

We linked this to a known issue in pip: https://github.com/pypa/pip/issues/2984 and verified that disabling the cache mechanism solves the issue (at least for the large packages we tested).

## What Changed?

Created a read-only version of `src/pip/_vendor/cachecontrol/adapter.py` in `src/pip/_internal/network/ro_cache_adapter.py` and replaced the original. This adapter disable the write-to-cache behavior when downloading a file, but it still reads from the cache when matching requests are found in the cache directory `~/.cache/pip/http`.

## How to test

1. Create a python repl
2. `pip install nvidia_cublas_cu11` and see the install succeed
3. `pip install pyyaml` and see that the download used the cached version